### PR TITLE
Fix installed mod counts and pagination

### DIFF
--- a/src/components/viewblock/Mods.svelte
+++ b/src/components/viewblock/Mods.svelte
@@ -254,18 +254,18 @@ $: isSearchingInstalledMods = isLoadingLocalMods || isLoadingInstalledMods;
 		setTimeout(() => {}, 500); // Delay to prevent scroll handler triggering during animated scroll
 	}
 
-	function updateEnabledDisabledLists() {
-		// Filter catalog mods - explicitly check for boolean values
-		enabledMods = paginatedMods.filter(
-			(mod) =>
-				$installationStatus[mod.title] &&
-				$modEnabledStore[mod.title] === true,
-		);
-		disabledMods = paginatedMods.filter(
-			(mod) =>
-				$installationStatus[mod.title] &&
-				$modEnabledStore[mod.title] === false,
-		);
+        function updateEnabledDisabledLists() {
+                // Filter catalog mods using the full filtered list to ensure counts span all pages
+                enabledMods = sortedAndFilteredMods.filter(
+                        (mod) =>
+                                $installationStatus[mod.title] &&
+                                $modEnabledStore[mod.title] === true,
+                );
+                disabledMods = sortedAndFilteredMods.filter(
+                        (mod) =>
+                                $installationStatus[mod.title] &&
+                                $modEnabledStore[mod.title] === false,
+                );
 
 		// Filter local mods - explicitly check for boolean values
 		enabledLocalMods = localMods.filter(

--- a/src/stores/modStore.ts
+++ b/src/stores/modStore.ts
@@ -68,7 +68,8 @@ export const uninstallDialogStore = writable<UninstallDialogState>({
 export const selectedModStore = writable<{ name: string; path: string } | null>(null);
 export const dependentsStore = writable<string[]>([]);
 export const currentPage = writable(1);
-export const itemsPerPage = writable(12);
+// Allow at least nine mods to appear before creating a new page
+export const itemsPerPage = writable(9);
 
 export type UninstallResult = {
 	success: boolean;


### PR DESCRIPTION
## Summary
- compute enabled/disabled mod counts using all filtered mods instead of just the current page
- show at least nine mods per page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859d4a1d4948332b2c71f7a044d7ca7