### PR TITLE
Fix mod cache refresh to purge missing mods

### DIFF
--- a/src/stores/modCache.ts
+++ b/src/stores/modCache.ts
@@ -11,12 +11,14 @@ const createModCache = () => {
 	const CACHE_TIMEOUT = 2000; // 2 seconds
 
 	// Core cache function that handles all operations
-	async function getModsFromCache(forceRefresh = false): Promise<InstalledMod[]> {
-		const now = Date.now();
+        async function getModsFromCache(forceRefresh = false): Promise<InstalledMod[]> {
+                const now = Date.now();
 
-		if (forceRefresh || lastFetchTime === 0 || now - lastFetchTime > CACHE_TIMEOUT) {
-			try {
-				const installed: InstalledMod[] = await invoke("get_installed_mods_from_db");
+                if (forceRefresh || lastFetchTime === 0 || now - lastFetchTime > CACHE_TIMEOUT) {
+                        try {
+                                // Clean up stale database entries before fetching
+                                await invoke("reindex_mods");
+                                const installed: InstalledMod[] = await invoke("get_installed_mods_from_db");
 				const formattedMods = installed.map((mod) => ({
 					name: mod.name,
 					path: mod.path,


### PR DESCRIPTION
## Summary
- ensure `reindex_mods` runs before refreshing installed mod cache

## Testing
- `cargo test -p bmm-lib -- --test-threads=1` *(fails: `gobject-2.0.pc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2b6b7e4c8332b23ebbc5ba496cd6