### PR TITLE
Fix reindex timing for installed mod cache

### DIFF
--- a/src/stores/modCache.ts
+++ b/src/stores/modCache.ts
@@ -11,12 +11,12 @@ const createModCache = () => {
 	const CACHE_TIMEOUT = 2000; // 2 seconds
 
 	// Core cache function that handles all operations
-	async function getModsFromCache(forceRefresh = false): Promise<InstalledMod[]> {
-		const now = Date.now();
+        async function getModsFromCache(forceRefresh = false): Promise<InstalledMod[]> {
+                const now = Date.now();
 
-		if (forceRefresh || lastFetchTime === 0 || now - lastFetchTime > CACHE_TIMEOUT) {
-			try {
-				const installed: InstalledMod[] = await invoke("get_installed_mods_from_db");
+               if (forceRefresh || lastFetchTime === 0 || now - lastFetchTime > CACHE_TIMEOUT) {
+                       try {
+                               const installed: InstalledMod[] = await invoke("get_installed_mods_from_db");
 				const formattedMods = installed.map((mod) => ({
 					name: mod.name,
 					path: mod.path,
@@ -52,10 +52,15 @@ const createModCache = () => {
 			return mods.some(m => m.name.toLowerCase() === modTitle.toLowerCase());
 		},
 
-		// Force refresh the cache
-		forceRefreshCache: async () => {
-			return getModsFromCache(true);
-		}
+               // Force refresh the cache
+               forceRefreshCache: async () => {
+                       try {
+                               await invoke("reindex_mods");
+                       } catch (error) {
+                               console.error("Failed to reindex mods:", error);
+                       }
+                       return getModsFromCache(true);
+               }
 	};
 };
 


### PR DESCRIPTION
## Summary
- run `reindex_mods` only when force refreshing the installed mod cache
- fetch installed mods normally without reindex side effects

## Testing
- `cargo test -p bmm-lib --manifest-path src-tauri/bmm-lib/Cargo.toml -- --test-threads=1` *(fails: `glib-2.0.pc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2b6b7e4c8332b23ebbc5ba496cd6